### PR TITLE
Expose encryption_algorithm option

### DIFF
--- a/lib/sidekiq-field-encryptor/encryptor.rb
+++ b/lib/sidekiq-field-encryptor/encryptor.rb
@@ -29,7 +29,7 @@ module SidekiqFieldEncryptor
     end
 
     def assert_key_configured
-      fail 'Encryption key not configured' if @encryption_key.nil?
+      raise 'Encryption key not configured' if @encryption_key.nil?
     end
 
     def encrypt(value)

--- a/lib/sidekiq-field-encryptor/version.rb
+++ b/lib/sidekiq-field-encryptor/version.rb
@@ -1,3 +1,3 @@
 module SidekiqFieldEncryptor
-  VERSION = '0.1.0'
+  VERSION = '0.1.0'.freeze
 end

--- a/spec/sidekiq-field-encryptor/encryptor_spec.rb
+++ b/spec/sidekiq-field-encryptor/encryptor_spec.rb
@@ -12,7 +12,8 @@ describe SidekiqFieldEncryptor::Client do
     end
     it 'fails when encryption is attempted' do
       client = SidekiqFieldEncryptor::Client.new(
-        encrypted_fields: { 'FooJob' => { 1 => true } })
+        encrypted_fields: { 'FooJob' => { 1 => true } }
+      )
       expect { client.call('FooJob', message, nil, nil) {} }
         .to raise_error('Encryption key not configured')
     end
@@ -22,9 +23,8 @@ describe SidekiqFieldEncryptor::Client do
     subject do
       SidekiqFieldEncryptor::Client.new(
         encryption_key: key,
-        encrypted_fields: {
-          'FooJob' => { 1 => true, 2 => %w(b d) }
-        })
+        encrypted_fields: { 'FooJob' => { 1 => true, 2 => %w(b d) } }
+      )
     end
 
     it 'encrypts only fields specified by the encryption config' do
@@ -71,7 +71,8 @@ describe SidekiqFieldEncryptor::Server do
     end
     it 'fails when decryption is attempted' do
       server = SidekiqFieldEncryptor::Server.new(
-        encrypted_fields: { 'FooJob' => { 1 => true } })
+        encrypted_fields: { 'FooJob' => { 1 => true } }
+      )
       expect { server.call('FooJob', message, nil) {} }
         .to raise_error('Encryption key not configured')
     end
@@ -81,9 +82,8 @@ describe SidekiqFieldEncryptor::Server do
     subject do
       SidekiqFieldEncryptor::Server.new(
         encryption_key: key,
-        encrypted_fields: {
-          'FooJob' => { 1 => true, 2 => %w(b d) }
-        })
+        encrypted_fields: { 'FooJob' => { 1 => true, 2 => %w(b d) } }
+      )
     end
 
     it 'decrypts all fields specified by the encryption config' do


### PR DESCRIPTION
We have a default aes-256-cbc algorithm in API (although I think a lot
of the columns have been converted to use GCM at this point), but
Sweetness uses a different algorithm (the default aes-256-gcm). This
means they can't talk to each other, which is problematic for obvious
reasons.

This fixes that by letting the caller specify the encryption algorithm,
thus ensuring that whatever API uses as its default is overridden.

---

cc @fancyremarker @blakepettersson 