### PR TITLE
Use JSON for serialization

### DIFF
--- a/lib/sidekiq-field-encryptor/encryptor.rb
+++ b/lib/sidekiq-field-encryptor/encryptor.rb
@@ -1,5 +1,6 @@
 require 'base64'
 require 'encryptor'
+require 'json'
 require 'sidekiq-field-encryptor/version'
 
 # This middleware configures encryption of any fields that can contain sensitive
@@ -21,30 +22,69 @@ require 'sidekiq-field-encryptor/version'
 # Will encrypt the values {'x' => 1} and 'b' when storing the job in Redis and
 # decrypt the values inside the client before the job is executed.
 module SidekiqFieldEncryptor
+  SERIALIZE_JSON = 'json'.freeze
+  SERIALIZE_MARHSALL = 'marshal'.freeze
+
   class Base
     def initialize(options = {})
       @encryption_key = options[:encryption_key]
       @encrypted_fields = options[:encrypted_fields] || {}
       @encryption_algorithm = options[:encryption_algorithm] || 'aes-256-gcm'
+
+      @serialization_method = options[:serialization_method] || SERIALIZE_JSON
+      @serialization_compat = options[:serialization_compat]
     end
 
     def assert_key_configured
       raise 'Encryption key not configured' if @encryption_key.nil?
     end
 
+    def serialize(value)
+      case @serialization_method
+      when SERIALIZE_JSON
+        JSON.generate(value, quirks_mode: true)
+      when SERIALIZE_MARHSALL
+        Marshal.dump(value)
+      else
+        raise "Invalid serialization_method: #{@serialization_method}"
+      end
+    end
+
+    def deserialize(method, value)
+      if !@serialization_compat && method != @serialization_method
+        raise "Invalid serialization_method received: #{method}"
+      end
+
+      case method
+      when SERIALIZE_JSON
+        JSON.parse(value, quirks_mode: true)
+      when SERIALIZE_MARHSALL, nil
+        # No method used to be Marshall, so we respect this here
+        Marshal.load(value)
+      else
+        raise "Invalid serialization_method: #{@serialization_method}"
+      end
+    end
+
     def encrypt(value)
-      plaintext = Marshal.dump(value)
+      plaintext = serialize(value)
       iv = OpenSSL::Cipher::Cipher.new(@encryption_algorithm).random_iv
       args = { key: @encryption_key, iv: iv, algorithm: @encryption_algorithm }
       ciphertext = ::Encryptor.encrypt(plaintext, **args)
-      [::Base64.encode64(ciphertext), ::Base64.encode64(iv)]
+      [
+        ::Base64.encode64(ciphertext),
+        ::Base64.encode64(iv),
+        @serialization_method
+      ]
     end
 
     def decrypt(encrypted)
-      ciphertext, iv = encrypted.map { |value| ::Base64.decode64(value) }
+      base64_ciphertext, base64_iv, serialization_method = encrypted
+      ciphertext = ::Base64.decode64(base64_ciphertext)
+      iv = ::Base64.decode64(base64_iv)
       args = { key: @encryption_key, iv: iv, algorithm: @encryption_algorithm }
       plaintext = ::Encryptor.decrypt(ciphertext, **args)
-      Marshal.load(plaintext)
+      deserialize(serialization_method, plaintext)
     end
 
     def process_message(message)


### PR DESCRIPTION
This exposes a compatibility mode (`serialization_compat` option) so
that we can first release the changes by serializing to JSON while
allowing the old format as well, then release a second time with
mandatory JSON serialization.

---

cc @fancyremarker 